### PR TITLE
Updating dal-indigo-fw-0 to allow Plex traffic

### DIFF
--- a/sites/indigo/devices/dal-indigo-fw-0.rsc
+++ b/sites/indigo/devices/dal-indigo-fw-0.rsc
@@ -214,7 +214,7 @@ add chain=forward action=accept in-interface=MANAGEMENT_VLAN out-interface=SERVE
 ## Allow MANAGEMENT_VLAN => SERVERS_STAGING_VLAN
 add chain=forward action=accept in-interface=MANAGEMENT_VLAN out-interface=SERVERS_STAGING_VLAN comment="accept MANAGEMENT_VLAN => SERVERS_STAGING_VLAN"
 
-## Alow Plex forward traffic
+## Alow WAN => SERVERS_VLAN (Plex dst-nat traffic)
 add chain=forward action=accept protocol=tcp dst-port=32400 out-interface=SERVERS_VLAN in-interface-list=WAN connection-nat-state=dstnat comment="accept DSTNAT => PLEX"
 
 # Finally drop everything else

--- a/sites/indigo/devices/dal-indigo-fw-0.rsc
+++ b/sites/indigo/devices/dal-indigo-fw-0.rsc
@@ -214,6 +214,9 @@ add chain=forward action=accept in-interface=MANAGEMENT_VLAN out-interface=SERVE
 ## Allow MANAGEMENT_VLAN => SERVERS_STAGING_VLAN
 add chain=forward action=accept in-interface=MANAGEMENT_VLAN out-interface=SERVERS_STAGING_VLAN comment="accept MANAGEMENT_VLAN => SERVERS_STAGING_VLAN"
 
+## Alow Plex forward traffic
+add chain=forward action=accept protocol=tcp dst-port=32400 out-interface=SERVERS_VLAN in-interface-list=WAN connection-nat-state=dstnat comment="accept DSTNAT => PLEX"
+
 # Finally drop everything else
 add chain=forward action=accept log=yes log-prefix=forward-catch comment="catchall" disabled=yes
 add chain=forward action=drop log=yes log-prefix=forward-drop comment="drop all other forward"
@@ -223,7 +226,15 @@ add chain=forward action=drop log=yes log-prefix=forward-drop comment="drop all 
 # NAT
 #
 
-/ip/firewall/nat/add chain=srcnat out-interface-list=WAN ipsec-policy=out,none action=masquerade comment="Default masquerade"
+/ip/firewall/nat
+
+# Masquerade outgoing packets as WAN IP
+add chain=srcnat out-interface-list=WAN ipsec-policy=out,none action=masquerade comment="Default masquerade"
+
+# Add more general NAT access here
+
+## dst-nat Plex => Vulcan
+add chain=dstnat action=dst-nat to-address=192.168.77.64 to-ports=32400 protocol=tcp in-interface-list=WAN dst-port=32405 ipsec-policy=in,none
 
 
 #

--- a/sites/indigo/devices/dal-indigo-fw-0.rsc
+++ b/sites/indigo/devices/dal-indigo-fw-0.rsc
@@ -168,17 +168,21 @@ add interface=IOT_INTERNET_VLAN    list=VLAN
 add interface=IOT_RESTRICTED_VLAN  list=VLAN
 add interface=SERVICES_VLAN        list=VLAN
 add interface=MANAGEMENT_VLAN      list=VLAN
-
 add interface=GENERAL_VLAN         list=LAN
-add interface=GUEST_VLAN           list=INTERNET_ONLY
 add interface=VPN_VLAN             list=LAN
 add interface=SERVERS_VLAN         list=LAN
+add interface=SERVICES_VLAN        list=LAN
+add interface=MANAGEMENT_VLAN      list=LAN
+add interface=GUEST_VLAN           list=INTERNET_ONLY
 add interface=SERVERS_STAGING_VLAN list=INTERNET_ONLY
 add interface=IOT_INTERNET_VLAN    list=INTERNET_ONLY
 add interface=IOT_RESTRICTED_VLAN  list=BLACKHOLE
-add interface=SERVICES_VLAN        list=LAN
-add interface=MANAGEMENT_VLAN      list=LAN
 add interface=MANAGEMENT_VLAN      list=MANAGEMENT
+add interface=GENERAL_VLAN         list=INTERNAL_PUBLIC_ACCESS
+add interface=GUEST_VLAN           list=INTERNAL_PUBLIC_ACCESS
+add interface=VPN_VLAN             list=INTERNAL_PUBLIC_ACCESS
+add interface=GENERAL_VLAN         list=INTERNAL_PRIVATE_ACCESS
+add interface=VPN_VLAN             list=INTERNAL_PRIVATE_ACCESS
 
 /ip/firewall/filter
 
@@ -214,8 +218,11 @@ add chain=forward action=accept in-interface=MANAGEMENT_VLAN out-interface=SERVE
 ## Allow MANAGEMENT_VLAN => SERVERS_STAGING_VLAN
 add chain=forward action=accept in-interface=MANAGEMENT_VLAN out-interface=SERVERS_STAGING_VLAN comment="accept MANAGEMENT_VLAN => SERVERS_STAGING_VLAN"
 
-## Alow WAN => SERVERS_VLAN (Plex dst-nat traffic)
+## Allow WAN => SERVERS_VLAN (Plex dst-nat traffic)
 add chain=forward action=accept protocol=tcp dst-port=32400 out-interface=SERVERS_VLAN in-interface-list=WAN connection-nat-state=dstnat comment="accept DSTNAT => PLEX"
+
+## Allow INTERNAL_PUBLIC_ACCESS => SERVERS_VLAN (Plex local traffic)
+add chain=forward action=accept protocol=tcp dst-port=32400 in-interface-list=INTERNAL_PUBLIC_ACCESS out-interface=SERVERS_VLAN comment="accept INTERNAL_PUBLIC_ACCESS => PLEX"
 
 # Finally drop everything else
 add chain=forward action=accept log=yes log-prefix=forward-catch comment="catchall" disabled=yes


### PR DESCRIPTION
This PR updates dal-indigo-fw-0 to allow Plex traffic from both WAN (Public) sources as well as LAN (Internal) sources.

The interface lists have been tweaked slightly to allow to differentiate between LAN sources that should have access to public services (eg. Plex) and non-public services (eg. Grafana)